### PR TITLE
BusinessHelper Facade and Factory class name resolver does not fallback to core namespace

### DIFF
--- a/tests/SprykerTest/Zed/Testify/_support/Helper/Business/BusinessHelper.php
+++ b/tests/SprykerTest/Zed/Testify/_support/Helper/Business/BusinessHelper.php
@@ -31,11 +31,6 @@ class BusinessHelper extends Module
     protected const BUSINESS_FACADE_CLASS_NAME_PATTERN = '\%1$s\%2$s\%3$s\Business\%3$sFacade';
     protected const SHARED_FACTORY_CLASS_NAME_PATTERN = '\%1$s\Shared\%2$s\%2$sSharedFactory';
 
-    protected const NON_STANDARD_NAMESPACE_PREFIXES = [
-        'SprykerShopTest',
-        'SprykerSdkTest',
-    ];
-
     /**
      * @var array
      */
@@ -171,13 +166,14 @@ class BusinessHelper extends Module
         $config = Configuration::config();
         $namespaceParts = explode('\\', $config['namespace']);
 
-        $classNameCandidate = sprintf(static::BUSINESS_FACADE_CLASS_NAME_PATTERN, 'Spryker', $namespaceParts[1], $moduleName);
+        $classNameCandidate = sprintf(static::BUSINESS_FACADE_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $moduleName);
+        $defaultClassNameCandidate = sprintf(static::BUSINESS_FACADE_CLASS_NAME_PATTERN, 'Spryker', $namespaceParts[1], $moduleName);
 
-        if (in_array($namespaceParts[0], static::NON_STANDARD_NAMESPACE_PREFIXES, true) && class_exists($classNameCandidate)) {
-            return $classNameCandidate;
+        if (class_exists($classNameCandidate) === false && class_exists($defaultClassNameCandidate)) {
+            return $defaultClassNameCandidate;
         }
 
-        return sprintf(static::BUSINESS_FACADE_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $moduleName);
+        return $classNameCandidate;
     }
 
     /**
@@ -288,13 +284,14 @@ class BusinessHelper extends Module
         $config = Configuration::config();
         $namespaceParts = explode('\\', $config['namespace']);
 
-        $classNameCandidate = sprintf(static::BUSINESS_FACTORY_CLASS_NAME_PATTERN, 'Spryker', $namespaceParts[1], $moduleName);
+        $classNameCandidate = sprintf(static::BUSINESS_FACTORY_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $moduleName);
+        $defaultClassNameCandidate = sprintf(static::BUSINESS_FACTORY_CLASS_NAME_PATTERN, 'Spryker', $namespaceParts[1], $moduleName);
 
-        if (in_array($namespaceParts[0], static::NON_STANDARD_NAMESPACE_PREFIXES, true) && class_exists($classNameCandidate)) {
-            return $classNameCandidate;
+        if (class_exists($classNameCandidate) === false && class_exists($defaultClassNameCandidate)) {
+            return $defaultClassNameCandidate;
         }
 
-        return sprintf(static::BUSINESS_FACTORY_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $moduleName);
+        return $classNameCandidate;
     }
 
     /**


### PR DESCRIPTION
## PR Description

If you use the BusinessHelper to get a modules Facade within a test, it always expects Factory and Facade to be available in module's test namespace. If you have not overridden Factory/Facade in project namespace for example, the BusinessHelper does not fallback to core namespace, like the Application/Locator would.

### Example:
Given there is no Facade at `Pyz\Zed\Mail\Business\MailFacade`, but in core at `Spryker\Zed\Mail\Business\MailFacade`
Testclass is in namespace `PyzTest\Zed\Mail\Business`

Calling `$this->tester->getFacade()` will result in 
```
[Error] Class '\Pyz\Zed\Mail\Business\MailFacade' not found

#1  /data/vendor/spryker/testify/tests/SprykerTest/Zed/Testify/_support/Helper/Business/BusinessHelper.php:161
#2  /data/vendor/spryker/testify/tests/SprykerTest/Zed/Testify/_support/Helper/Business/BusinessHelper.php:114
#3  SprykerTest\Zed\Testify\Helper\Business\BusinessHelper->getFacade
```

The provided fix uses a fallback for the core namespace if the requested class exists.
If Factory/Facade is also missing in core namespace, it will not use core namespace for FQCN, so the error message shows the correct path. 

I'm not so sure about `NON_STANDARD_NAMESPACE_PREFIXES`, but I don't think that we have to maintain this list anymore.


## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
