### PR TITLE
Fix wrong removal of Test class postfix

### DIFF
--- a/tests/SprykerTest/Shared/Testify/_support/Helper/ClassResolverTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/ClassResolverTrait.php
@@ -69,7 +69,7 @@ trait ClassResolverTrait
         $namespaceParts = explode('\\', $config['namespace']);
 
         $classNameCandidates = [];
-        $classNameCandidates[] = sprintf($classNamePattern, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $moduleName);
+        $classNameCandidates[] = sprintf($classNamePattern, preg_replace('/Test$/', '', $namespaceParts[0]), $namespaceParts[1], $moduleName);
 
         foreach ($this->coreNamespaces as $coreNamespace) {
             $classNameCandidates[] = sprintf($classNamePattern, $coreNamespace, $namespaceParts[1], $moduleName);


### PR DESCRIPTION
## PR Description

Currently resolved class names are wrong whenever the first part of the fully qualified class name ends with any of the following characters in this set `[Test]` in the `resolveClassName` method.

For example suppose I have a class named `CodeEssence\Zed\Category\CategoryConfig` and method is called with `$moduleName=Category` the following list of `$classNameCandidates` is generated:

```php
array(3) {
  [0]=>
  string(43) "\CodeEssenc\Zed\Category\CategoryConfig" // missing ending e char of CodeEssence string
  [1]=>
  string(46) "\Spryker\Zed\Category\CategoryConfig"
  [2]=>
  string(50) "\SprykerShop\Zed\Category\CategoryConfig"
}
```
where the expected list is: 

```php
array(3) {
  [0]=>
  string(43) "\CodeEssence\Zed\Category\CategoryConfig"
  [1]=>
  string(46) "\Spryker\Zed\Category\CategoryConfig"
  [2]=>
  string(50) "\SprykerShop\Zed\Category\CategoryConfig"
}
```

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
