### PR TITLE
Overwrite Methode to only set the Header if it was not set manually /…

### DIFF
--- a/tests/SprykerTest/Glue/Testify/_support/Helper/GlueRest.php
+++ b/tests/SprykerTest/Glue/Testify/_support/Helper/GlueRest.php
@@ -612,4 +612,18 @@ class GlueRest extends REST implements LastConnectionProviderInterface
 
         return $this->jsonPathModule;
     }
+
+    /**
+     * @param $name
+     * @param $value
+     * @param false $overwrite
+     *
+     * Overwrite Methode to only set the Header if it was not set manually / upfront.
+     */
+    public function haveHttpHeader($name, $value, $overwrite = false)
+    {
+        if($overwrite || !isset($this->connectionModule->headers[$name])){
+            parent::haveHttpHeader($name, $value);
+        }
+    }
 }


### PR DESCRIPTION
… upfront

As it is today you can't use the REST Helper for non Glue endpoints anymore as the header is overwritten all the time by prepareHeaders. This way I can set it to something else for non Glue Requests.

## PR Description

I overwrite the haveHttpHeader header to only overwrite a header if the additional parameter $overwrite is true ( false by default). As the prepareHeaders methode is not setting this new parameter, I can prevent overwriting Headers that was set manually by purpose  

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
