### PR TITLE
Change visibility level for getDataCleanupHelper

### DIFF
--- a/tests/SprykerTest/Shared/Testify/_support/Helper/DataCleanupHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/DataCleanupHelperTrait.php
@@ -12,7 +12,7 @@ trait DataCleanupHelperTrait
     /**
      * @return \SprykerTest\Shared\Testify\Helper\DataCleanupHelper
      */
-    private function getDataCleanupHelper()
+    protected function getDataCleanupHelper()
     {
         /** @var \SprykerTest\Shared\Testify\Helper\DataCleanupHelper $dataCleanerHelper */
         $dataCleanerHelper = $this->getModule('\\' . DataCleanupHelper::class);


### PR DESCRIPTION
We experienced problems with "private" visibility level for this trait.
In this case we can't reuse trait in child classes. This example illustrates the problem

```php
<?php

declare(strict_types = 1);

trait ATrait
{
    private function foo()
    {
        echo 'from ATrait';
    }
}

class A
{
    use ATrait;

    public function bar()
    {
        $this->foo();
    }
}

class B extends A
{
    private function foo()
    {
        echo 'from BClass';
    }
}

$b = new B;
$b->bar();
```

The result will be:

```
from ATrait
```

In other words it's impossible to override ONLY getDataCleanupHelper (if we need to return another instance). We must override entire trait to reuse data cleanup features like we do in our project

TBD

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
