### PR TITLE
Fix removal of Test suffix

### DIFF
--- a/tests/SprykerTest/Glue/Testify/_support/Helper/DependencyProviderHelper.php
+++ b/tests/SprykerTest/Glue/Testify/_support/Helper/DependencyProviderHelper.php
@@ -17,11 +17,13 @@ use Spryker\Glue\Kernel\Container;
 use Spryker\Shared\Kernel\ContainerMocker\ContainerGlobals;
 use Spryker\Shared\Kernel\ContainerMocker\ContainerMocker;
 use SprykerTest\Shared\Testify\Helper\ModuleNameTrait;
+use SprykerTest\Shared\Testify\Helper\SourceNamespaceTrait;
 
 class DependencyProviderHelper extends Module
 {
     use ContainerMocker;
     use ModuleNameTrait;
+    use SourceNamespaceTrait;
 
     /**
      * @var string
@@ -134,7 +136,7 @@ class DependencyProviderHelper extends Module
         $config = Configuration::config();
         $namespaceParts = explode('\\', $config['namespace']);
 
-        return sprintf(static::DEPENDENCY_PROVIDER_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $moduleName);
+        return sprintf(static::DEPENDENCY_PROVIDER_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $moduleName);
     }
 
     /**

--- a/tests/SprykerTest/Glue/Testify/_support/Helper/FactoryHelper.php
+++ b/tests/SprykerTest/Glue/Testify/_support/Helper/FactoryHelper.php
@@ -18,12 +18,14 @@ use Spryker\Glue\Kernel\Container;
 use SprykerTest\Shared\Testify\Helper\ConfigHelper;
 use SprykerTest\Shared\Testify\Helper\ConfigHelperTrait;
 use SprykerTest\Shared\Testify\Helper\ModuleNameTrait;
+use SprykerTest\Shared\Testify\Helper\SourceNamespaceTrait;
 
 class FactoryHelper extends Module
 {
     use DependencyProviderHelperTrait;
     use ConfigHelperTrait;
     use ModuleNameTrait;
+    use SourceNamespaceTrait;
 
     /**
      * @var string
@@ -118,7 +120,7 @@ class FactoryHelper extends Module
         $namespaceParts = explode('\\', $config['namespace']);
         $factoryClassNameCandidate = sprintf(static::FACTORY_CLASS_NAME_PATTERN, 'Spryker', $moduleName);
 
-        return sprintf(static::FACTORY_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $moduleName);
+        return sprintf(static::FACTORY_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $moduleName);
     }
 
     /**

--- a/tests/SprykerTest/Service/Testify/_support/Helper/DependencyProviderHelper.php
+++ b/tests/SprykerTest/Service/Testify/_support/Helper/DependencyProviderHelper.php
@@ -19,12 +19,14 @@ use Spryker\Shared\Kernel\ContainerMocker\ContainerGlobals;
 use Spryker\Shared\Kernel\ContainerMocker\ContainerMocker;
 use SprykerTest\Service\Container\Helper\ContainerHelperTrait;
 use SprykerTest\Shared\Testify\Helper\ModuleNameTrait;
+use SprykerTest\Shared\Testify\Helper\SourceNamespaceTrait;
 
 class DependencyProviderHelper extends Module
 {
     use ModuleNameTrait;
     use ContainerMocker;
     use ContainerHelperTrait;
+    use SourceNamespaceTrait;
 
     /**
      * @var string
@@ -168,7 +170,7 @@ class DependencyProviderHelper extends Module
             return $classNameCandidate;
         }
 
-        return sprintf(static::DEPENDENCY_PROVIDER_CLASS_NAME_PATTERN, rtrim($namespacePrefix, 'Test'), $moduleName);
+        return sprintf(static::DEPENDENCY_PROVIDER_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $moduleName);
     }
 
     /**

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/BusinessHelper.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/BusinessHelper.php
@@ -24,6 +24,8 @@ use Spryker\Zed\Testify\Locator\Business\BusinessLocator as Locator;
  */
 class BusinessHelper extends Module
 {
+    use SourceNamespaceTrait;
+
     /**
      * @var string
      */
@@ -145,7 +147,7 @@ class BusinessHelper extends Module
         $config = Configuration::config();
         $namespaceParts = explode('\\', $config['namespace']);
 
-        return sprintf(static::BUSINESS_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $namespaceParts[2]);
+        return sprintf(static::BUSINESS_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $namespaceParts[1], $namespaceParts[2]);
     }
 
     /**

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/FactoryHelper.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/FactoryHelper.php
@@ -17,6 +17,8 @@ use Spryker\Shared\Kernel\AbstractSharedFactory;
 
 class FactoryHelper extends Module
 {
+    use SourceNamespaceTrait;
+
     /**
      * @var string
      */
@@ -91,7 +93,7 @@ class FactoryHelper extends Module
         $config = Configuration::config();
         $namespaceParts = explode('\\', $config['namespace']);
 
-        return sprintf(static::SHARED_FACTORY_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[2]);
+        return sprintf(static::SHARED_FACTORY_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $namespaceParts[2]);
     }
 
     /**

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/SourceNamespaceTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/SourceNamespaceTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Shared\Testify\Helper;
+
+trait SourceNamespaceTrait
+{
+    /**
+     * @param string $namespace
+     *
+     * @return string
+     */
+    protected function removeTestSuffix(string $namespace): string
+    {
+        return preg_replace('#Test$#', '', $namespace);
+    }
+}

--- a/tests/SprykerTest/Yves/Testify/_support/Helper/DependencyProviderHelper.php
+++ b/tests/SprykerTest/Yves/Testify/_support/Helper/DependencyProviderHelper.php
@@ -17,11 +17,13 @@ use Spryker\Shared\Kernel\ContainerMocker\ContainerMocker;
 use Spryker\Yves\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Yves\Kernel\Container;
 use SprykerTest\Shared\Testify\Helper\ModuleNameTrait;
+use SprykerTest\Shared\Testify\Helper\SourceNamespaceTrait;
 
 class DependencyProviderHelper extends Module
 {
     use ContainerMocker;
     use ModuleNameTrait;
+    use SourceNamespaceTrait;
 
     /**
      * @var string
@@ -140,7 +142,7 @@ class DependencyProviderHelper extends Module
             return $classNameCandidate;
         }
 
-        return sprintf(static::DEPENDENCY_PROVIDER_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $moduleName);
+        return sprintf(static::DEPENDENCY_PROVIDER_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $moduleName);
     }
 
     /**

--- a/tests/SprykerTest/Zed/Testify/_support/Helper/CommunicationHelper.php
+++ b/tests/SprykerTest/Zed/Testify/_support/Helper/CommunicationHelper.php
@@ -17,12 +17,15 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 use Spryker\Zed\Kernel\Communication\AbstractCommunicationFactory;
 use Spryker\Zed\Testify\Locator\Business\BusinessLocator as Locator;
 use SprykerTest\Shared\Testify\Helper\ConfigHelper;
+use SprykerTest\Shared\Testify\Helper\SourceNamespaceTrait;
 
 /**
  * @deprecated Use {@link \SprykerTest\Zed\Testify\Helper\Communication\CommunicationHelper} instead.
  */
 class CommunicationHelper extends Module
 {
+    use SourceNamespaceTrait;
+
     /**
      * @var string
      */
@@ -123,7 +126,7 @@ class CommunicationHelper extends Module
         $config = Configuration::config();
         $namespaceParts = explode('\\', $config['namespace']);
 
-        return sprintf(static::COMMUNICATION_FACTORY_CLASS_NAME_PATTERN, rtrim($namespaceParts[0], 'Test'), $namespaceParts[1], $namespaceParts[2]);
+        return sprintf(static::COMMUNICATION_FACTORY_CLASS_NAME_PATTERN, $this->removeTestSuffix($namespaceParts[0]), $namespaceParts[1], $namespaceParts[2]);
     }
 
     /**


### PR DESCRIPTION
## PR Description

Fixing removal of the Test suffix of the test namespace.

As-is (with wrong usage of `rtrim`):
```
php > echo rtrim('DnsTest', 'Test');
Dn
php > echo rtrim('BestTest', 'Test');
B
php > echo rtrim('BestTestTest', 'Test');
B
```

Expected to be:
```
php > echo preg_replace('#Test$#', '', 'DnsTest');
Dns
php > echo preg_replace('#Test$#', '', 'BestTest');
Best
php > echo preg_replace('#Test$#', '', 'BestTestTest');
BestTest
```

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
