### PR TITLE
Type hinting for getModule & config 

### DIFF
--- a/tests/SprykerTest/Client/Testify/_support/Helper/ClientHelperTrait.php
+++ b/tests/SprykerTest/Client/Testify/_support/Helper/ClientHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Client\Testify\Helper;
 
+use \Codeception\Module;
+
 trait ClientHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait ClientHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Client/Testify/_support/Helper/ConfigHelperTrait.php
+++ b/tests/SprykerTest/Client/Testify/_support/Helper/ConfigHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Client\Testify\Helper;
 
+use \Codeception\Module;
+
 trait ConfigHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait ConfigHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Client/Testify/_support/Helper/DependencyProviderHelperTrait.php
+++ b/tests/SprykerTest/Client/Testify/_support/Helper/DependencyProviderHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Client\Testify\Helper;
 
+use \Codeception\Module;
+
 trait DependencyProviderHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DependencyProviderHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Client/Testify/_support/Helper/FactoryHelperTrait.php
+++ b/tests/SprykerTest/Client/Testify/_support/Helper/FactoryHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Client\Testify\Helper;
 
+use \Codeception\Module;
+
 trait FactoryHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait FactoryHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Glue/Testify/_support/Helper/DependencyProviderHelperTrait.php
+++ b/tests/SprykerTest/Glue/Testify/_support/Helper/DependencyProviderHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Glue\Testify\Helper;
 
+use \Codeception\Module;
+
 trait DependencyProviderHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DependencyProviderHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Glue/Testify/_support/Helper/FactoryHelperTrait.php
+++ b/tests/SprykerTest/Glue/Testify/_support/Helper/FactoryHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Glue\Testify\Helper;
 
+use \Codeception\Module;
+
 trait FactoryHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait FactoryHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Glue/Testify/_support/Helper/OpenApi3.php
+++ b/tests/SprykerTest/Glue/Testify/_support/Helper/OpenApi3.php
@@ -30,7 +30,7 @@ class OpenApi3 extends Module
     /**
      * @var array
      */
-    protected $config = [
+    protected array $config = [
         'schema' => '',
     ];
 

--- a/tests/SprykerTest/Service/Testify/_support/Helper/DependencyProviderHelperTrait.php
+++ b/tests/SprykerTest/Service/Testify/_support/Helper/DependencyProviderHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Service\Testify\Helper;
 
+use \Codeception\Module;
+
 trait DependencyProviderHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DependencyProviderHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Service/Testify/_support/Helper/ServiceHelperTrait.php
+++ b/tests/SprykerTest/Service/Testify/_support/Helper/ServiceHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Service\Testify\Helper;
 
+use \Codeception\Module;
+
 trait ServiceHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait ServiceHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/ClassHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/ClassHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use \Codeception\Module;
+
 trait ClassHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait ClassHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/ConfigHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/ConfigHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use \Codeception\Module;
+
 trait ConfigHelperTrait
 {
     /**
@@ -36,5 +38,5 @@ trait ConfigHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/DataCleanupHelper.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/DataCleanupHelper.php
@@ -21,7 +21,7 @@ class DataCleanupHelper extends Module
     /**
      * @var array
      */
-    protected $config = ['cleanup' => true];
+    protected array $config = ['cleanup' => true];
 
     /**
      * @param \Closure $closure

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/DataCleanupHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/DataCleanupHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use \Codeception\Module;
+
 trait DataCleanupHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DataCleanupHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/DependencyHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/DependencyHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use \Codeception\Module;
+
 trait DependencyHelperTrait
 {
     /**
@@ -36,5 +38,5 @@ trait DependencyHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/Environment.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/Environment.php
@@ -28,7 +28,7 @@ class Environment extends Module
     /**
      * @var array
      */
-    protected $config = [
+    protected array $config = [
         self::CONFIG_IS_ISOLATED_MODULE_TEST => false,
     ];
 

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/FactoryHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/FactoryHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use \Codeception\Module;
+
 trait FactoryHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait FactoryHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/LocatorHelper.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/LocatorHelper.php
@@ -27,7 +27,7 @@ class LocatorHelper extends Module
     /**
      * @var array
      */
-    protected $config = [
+    protected array $config = [
         'projectNamespaces' => [],
         'coreNamespaces' => [
             'SprykerShop',

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/LocatorHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/LocatorHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use Codeception\Module;
+
 trait LocatorHelperTrait
 {
     /**
@@ -33,5 +35,5 @@ trait LocatorHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/VirtualFilesystemHelperTrait.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/VirtualFilesystemHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Shared\Testify\Helper;
 
+use \Codeception\Module;
+
 trait VirtualFilesystemHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait VirtualFilesystemHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Shared/Testify/_support/Helper/ZedBootstrap.php
+++ b/tests/SprykerTest/Shared/Testify/_support/Helper/ZedBootstrap.php
@@ -43,7 +43,7 @@ class ZedBootstrap extends Framework implements DependsOnModule
     /**
      * @var array<string, array>
      */
-    protected $config = [
+    protected array $config = [
         self::CONFIG_KEY_SERVICE_PROVIDER => [],
         self::CONFIG_KEY_APPLICATION_PLUGINS => [],
     ];

--- a/tests/SprykerTest/Yves/Testify/_support/Helper/DependencyProviderHelperTrait.php
+++ b/tests/SprykerTest/Yves/Testify/_support/Helper/DependencyProviderHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Yves\Testify\Helper;
 
+use \Codeception\Module;
+
 trait DependencyProviderHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DependencyProviderHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Yves/Testify/_support/Helper/FactoryHelperTrait.php
+++ b/tests/SprykerTest/Yves/Testify/_support/Helper/FactoryHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Yves\Testify\Helper;
 
+use \Codeception\Module;
+
 trait FactoryHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait FactoryHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Zed/Testify/_support/Helper/Business/BusinessHelperTrait.php
+++ b/tests/SprykerTest/Zed/Testify/_support/Helper/Business/BusinessHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Zed\Testify\Helper\Business;
 
+use Codeception\Module;
+
 trait BusinessHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait BusinessHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Zed/Testify/_support/Helper/Business/DependencyProviderHelperTrait.php
+++ b/tests/SprykerTest/Zed/Testify/_support/Helper/Business/DependencyProviderHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Zed\Testify\Helper\Business;
 
+use Codeception\Module;
+
 trait DependencyProviderHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DependencyProviderHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Zed/Testify/_support/Helper/Communication/CommunicationHelperTrait.php
+++ b/tests/SprykerTest/Zed/Testify/_support/Helper/Communication/CommunicationHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Zed\Testify\Helper\Communication;
 
+use \Codeception\Module;
+
 trait CommunicationHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait CommunicationHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }

--- a/tests/SprykerTest/Zed/Testify/_support/Helper/Communication/DependencyProviderHelperTrait.php
+++ b/tests/SprykerTest/Zed/Testify/_support/Helper/Communication/DependencyProviderHelperTrait.php
@@ -7,6 +7,8 @@
 
 namespace SprykerTest\Zed\Testify\Helper\Communication;
 
+use Codeception\Module;
+
 trait DependencyProviderHelperTrait
 {
     /**
@@ -25,5 +27,5 @@ trait DependencyProviderHelperTrait
      *
      * @return \Codeception\Module
      */
-    abstract protected function getModule($name);
+    abstract protected function getModule(string $name): Module;
 }


### PR DESCRIPTION
## PR Description
chore(types on methods): adding types on getModule function for codeception 5 migration

following up to: #6 

## Touchpoints

In comments

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
