### PR TITLE
Don't call properties directly on faker object, use method instead

### DIFF
--- a/src/Spryker/Shared/Testify/AbstractDataBuilder.php
+++ b/src/Spryker/Shared/Testify/AbstractDataBuilder.php
@@ -271,7 +271,10 @@ abstract class AbstractDataBuilder
         }
 
         // @codingStandardsIgnoreStart
-        return eval("return static::\$faker->$rule;");
+        if (strpos($rule, '(') !== false) {
+            return eval("return static::\$faker->$rule;");
+        }
+        return eval("return static::\$faker->$rule();");
         // @codingStandardsIgnoreEnd
     }
 


### PR DESCRIPTION
## PR Description

Faker deprecated using properties directly [some time ago](https://github.com/FakerPHP/Faker/pull/164), but this piece of code was still using it like that. I found this issue because one of our unit tests was pretty slow (took ~1 second) and is now 10x faster.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
